### PR TITLE
chore: update action to new repository location

### DIFF
--- a/.github/workflows/sync-secrets.yml
+++ b/.github/workflows/sync-secrets.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Sync secrets
-        uses: google/secrets-sync-action@v1.3.1
+        uses: jpoehnelt/secrets-sync-action@v1.3.1
         with:
           SECRETS: |
             ^DOCKER_.*


### PR DESCRIPTION
This is a PR to update the action to the new repository location from https://github.com/google/secrets-sync-action to https://github.com/jpoehnelt/secrets-sync-action. Note that GitHub does redirect the old repository to the new one, so this is more housekeeping than anything else.